### PR TITLE
💚 GitHub ActionsでのBunのバージョンを`1.0.16`で固定

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.0.16
 
       - name: Install dependencies
         run: bun install
@@ -28,6 +30,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.0.16
 
       - name: Install dependencies
         run: bun install
@@ -46,6 +50,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.0.16
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.0.16
 
       - name: Install Dependencies
         run: bun install


### PR DESCRIPTION
インストールでコケるので暫定対策

```
bun install v1.0.17 (5e60861c)
 Resolving dependencies
 Resolved, downloaded and extracted [2]
 Saved lockfile
/usr/bin/bash: line 1: node-gyp-build: command not found

error: install script from "utf-8-validate" exited with code 127
Error: Process completed with exit code 127.
```